### PR TITLE
Enhance About page with timeline

### DIFF
--- a/frontends/portfolio/src/app/about/page.tsx
+++ b/frontends/portfolio/src/app/about/page.tsx
@@ -50,14 +50,6 @@ export default function About() {
         composing game soundtracks.
       </p>
       <Timeline items={items} />
-      <h2 className="text-2xl font-bold mt-12 mb-4">Full Story</h2>
-      <p className="text-gray-600 mb-8">
-        Father. Husband. Engineer. My journey began at nine, when strict
-        “one‑hour‑of‑games” rules pushed me from playing to making them.
-        Mr Hossein Rezaei introduced me to QBasic, and curiosity did the rest. At
-        17 I sold a WinAmp‑style player with playlist support—proof that passion
-        could pay.
-      </p>
     </AnimatedSection>
   );
 }

--- a/frontends/portfolio/src/app/about/page.tsx
+++ b/frontends/portfolio/src/app/about/page.tsx
@@ -1,9 +1,63 @@
 import { AnimatedSection } from "@/components/AnimatedSection";
+import { Timeline, TimelineItem } from "@/components/Timeline";
+
+const items: TimelineItem[] = [
+  {
+    year: 1998,
+    title: "First QBasic Game",
+    description: "At age 9 I wrote my first game, discovering the magic of code.",
+  },
+  {
+    year: 2006,
+    title: "First Software Sale",
+    description: "Built and sold a WinAmp‑inspired music player with playlist support.",
+  },
+  {
+    year: "2010‑2014",
+    title: "Startup Roller‑Coaster",
+    description: "Founded 7 startups: 2 successes, 5 lessons learned.",
+  },
+  {
+    year: "2015‑2021",
+    title: "Freelance Full‑Stack & DevOps",
+    description: "Delivered 30+ production releases across e‑commerce, fintech, health.",
+  },
+  {
+    year: 2022,
+    title: "Moved to Australia",
+    description: "Relocated to Sydney to expand global reach and embrace contract leadership.",
+  },
+  {
+    year: "2023‑Now",
+    title: "Senior SE & Integrations Lead @ Vyro",
+    description: "Scaled multi‑tenant AWS platform to 1 M+ monthly visits; cut deploy time 50 %.",
+  },
+  {
+    year: "Side Quests",
+    title: "Community & Hobbies",
+    description: "Teach coding to kids, develop indie games, maintain open‑source ML tools.",
+  },
+];
+
 export default function About() {
   return (
     <AnimatedSection>
       <h1 className="text-3xl font-bold mb-6">About Me</h1>
-      <p className="text-gray-600 mb-8">Coming soon.</p>
+      <p className="text-gray-600 mb-8">
+        I’m Bardia Mazaheri, a contract Tech Lead who helps SaaS teams ship faster
+        and safer by blending backend engineering, DevOps automation, and
+        integration architecture—all while raising a family and occasionally
+        composing game soundtracks.
+      </p>
+      <Timeline items={items} />
+      <h2 className="text-2xl font-bold mt-12 mb-4">Full Story</h2>
+      <p className="text-gray-600 mb-8">
+        Father. Husband. Engineer. My journey began at nine, when strict
+        “one‑hour‑of‑games” rules pushed me from playing to making them.
+        Mr Hossein Rezaei introduced me to QBasic, and curiosity did the rest. At
+        17 I sold a WinAmp‑style player with playlist support—proof that passion
+        could pay.
+      </p>
     </AnimatedSection>
   );
 }

--- a/frontends/portfolio/src/components/Timeline.tsx
+++ b/frontends/portfolio/src/components/Timeline.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { motion } from "framer-motion";
 
 export interface TimelineItem {

--- a/frontends/portfolio/src/components/Timeline.tsx
+++ b/frontends/portfolio/src/components/Timeline.tsx
@@ -1,0 +1,27 @@
+import { motion } from "framer-motion";
+
+export interface TimelineItem {
+  year: string | number;
+  title: string;
+  description: string;
+}
+
+export const Timeline = ({ items }: { items: TimelineItem[] }) => (
+  <ol className="relative border-l border-gray-200 pl-6">
+    {items.map((item, idx) => (
+      <motion.li
+        key={idx}
+        initial={{ opacity: 0, x: -20 }}
+        whileInView={{ opacity: 1, x: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.4, delay: idx * 0.1 }}
+        className="relative mb-8 ml-4"
+      >
+        <span className="absolute -left-6 top-1 w-3 h-3 bg-gray-900 rounded-full" />
+        <time className="font-semibold text-gray-900">{item.year}</time>
+        <h3 className="text-lg font-bold">{item.title}</h3>
+        <p className="text-gray-600">{item.description}</p>
+      </motion.li>
+    ))}
+  </ol>
+);


### PR DESCRIPTION
## Summary
- introduce `Timeline` component with framer-motion animations
- populate the About page with a summary, animated timeline and full story text

## Testing
- `pnpm --filter ./frontends/portfolio lint`
- `pnpm --filter ./frontends/portfolio build` *(fails: unable to fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_687b5624b194832588ab007bc4b6149d