### PR TITLE
Improve about timeline styles

### DIFF
--- a/frontends/portfolio/src/components/Timeline.tsx
+++ b/frontends/portfolio/src/components/Timeline.tsx
@@ -9,7 +9,7 @@ export interface TimelineItem {
 }
 
 export const Timeline = ({ items }: { items: TimelineItem[] }) => (
-  <ol className="relative border-l border-gray-200 pl-6">
+  <ol className="relative border-l border-secondary-300 pl-10">
     {items.map((item, idx) => (
       <motion.li
         key={idx}
@@ -17,12 +17,20 @@ export const Timeline = ({ items }: { items: TimelineItem[] }) => (
         whileInView={{ opacity: 1, x: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.4, delay: idx * 0.1 }}
-        className="relative mb-8 ml-4"
+        className="relative mb-12 ml-6"
       >
-        <span className="absolute -left-6 top-1 w-3 h-3 bg-gray-900 rounded-full" />
-        <time className="font-semibold text-gray-900">{item.year}</time>
-        <h3 className="text-lg font-bold">{item.title}</h3>
-        <p className="text-gray-600">{item.description}</p>
+        <span className="absolute -left-5 top-3 w-4 h-4 rounded-full bg-gradient-to-b from-secondary-400 to-secondary-600 border-2 border-white shadow" />
+        <div className="flex gap-4">
+          <div className="w-24 text-right pr-2">
+            <time className="block text-2xl font-extrabold text-secondary-700">
+              {item.year}
+            </time>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">{item.title}</h3>
+            <p className="text-gray-700">{item.description}</p>
+          </div>
+        </div>
       </motion.li>
     ))}
   </ol>

--- a/frontends/portfolio/tailwind.config.ts
+++ b/frontends/portfolio/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { amber } from "tailwindcss/colors";
 
 export default {
   content: [
@@ -11,6 +12,7 @@ export default {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        secondary: amber,
       },
     },
   },


### PR DESCRIPTION
## Summary
- style the about page timeline with bigger year blocks and golden gradient accents
- add `secondary` color to Tailwind theme using the `amber` palette

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_687b5a2834988325977f75d90b6b5f5e