### PR TITLE
Add services page and update nav

### DIFF
--- a/frontends/portfolio/src/app/experience/page.tsx
+++ b/frontends/portfolio/src/app/experience/page.tsx
@@ -1,9 +1,0 @@
-import { AnimatedSection } from "@/components/AnimatedSection";
-export default function Experience() {
-  return (
-    <AnimatedSection>
-      <h1 className="text-3xl font-bold mb-6">Experience</h1>
-      <p className="text-gray-600 mb-8">Coming soon.</p>
-    </AnimatedSection>
-  );
-}

--- a/frontends/portfolio/src/app/services/page.tsx
+++ b/frontends/portfolio/src/app/services/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { AnimatedSection } from "@/components/AnimatedSection";
 
 export default function Services() {
@@ -13,7 +15,23 @@ export default function Services() {
         <li>Integrating third-party services and APIs</li>
         <li>Leading engineering teams and mentoring developers</li>
         <li>Reviewing codebases and advising on best practices</li>
+        <li>Contract-based software development for startups and businesses</li>
+        <li>Leading and managing cross-functional teams (design, QA, PM, devs)</li>
+        <li>Consulting as a fractional CTO, Tech Lead, or Scrum Master</li>
+        <li>Investing in small-scale game or tech projects with strong teams</li>
       </ul>
+
+      <div className="mt-10">
+        <p className="text-lg font-medium text-gray-700 mb-4">
+          Have a project or looking for a reliable partner?
+        </p>
+        <a
+          href="/contact"
+          className="inline-block px-6 py-3 rounded-full bg-gray-900 text-white hover:bg-gray-700 transition-colors duration-300"
+        >
+          Get in Touch
+        </a>
+      </div>
     </AnimatedSection>
   );
 }

--- a/frontends/portfolio/src/app/services/page.tsx
+++ b/frontends/portfolio/src/app/services/page.tsx
@@ -1,0 +1,19 @@
+import { AnimatedSection } from "@/components/AnimatedSection";
+
+export default function Services() {
+  return (
+    <AnimatedSection>
+      <h1 className="text-3xl font-bold mb-6">Services</h1>
+      <p className="text-gray-600 mb-8">
+        I help SaaS teams deliver reliable software faster. Here are some of the ways I can assist:
+      </p>
+      <ul className="list-disc pl-5 space-y-2 text-gray-800">
+        <li>Architecting scalable cloud infrastructure and backend systems</li>
+        <li>Automating CI/CD pipelines and developer workflows</li>
+        <li>Integrating third-party services and APIs</li>
+        <li>Leading engineering teams and mentoring developers</li>
+        <li>Reviewing codebases and advising on best practices</li>
+      </ul>
+    </AnimatedSection>
+  );
+}

--- a/frontends/portfolio/src/components/Navbar.tsx
+++ b/frontends/portfolio/src/components/Navbar.tsx
@@ -10,7 +10,8 @@ const links = [
   { href: "/writing", label: "Writing" },
   { href: "/open-source", label: "Open Source" },
   { href: "/skills", label: "Skills" },
-  { href: "/about", label: "About" },
+  { href: "/services", label: "Services" },
+  { href: "/about", label: "About Me" },
   { href: "/contact", label: "Contact" },
 ];
 

--- a/frontends/portfolio/src/components/Navbar.tsx
+++ b/frontends/portfolio/src/components/Navbar.tsx
@@ -10,7 +10,6 @@ const links = [
   { href: "/writing", label: "Writing" },
   { href: "/open-source", label: "Open Source" },
   { href: "/skills", label: "Skills" },
-  { href: "/experience", label: "Experience" },
   { href: "/about", label: "About" },
   { href: "/contact", label: "Contact" },
 ];


### PR DESCRIPTION
## Summary
- add a new `/services` page
- remove the `Experience` link from the navbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c7529a3e08325a6561b72e948c227